### PR TITLE
fix: update models to match given jsons structure

### DIFF
--- a/src/app/core/models/chart-data.model.ts
+++ b/src/app/core/models/chart-data.model.ts
@@ -1,12 +1,45 @@
 export interface ChartDataPoint {
-    date: Date;
-    value: number;
-  }
+  datetimeLastPrice: string;
+  datetimeLastPriceTs: number;
+  lastPrice: number;
+  highPrice: number;
+  lowPrice: number;
+  openPrice: number;
+  closePrice: number;
+  volume: number;
+  volumeMoney: number;
+  performanceRelative: number;
+  performanceAbsolute: number;
+  tend: 'up' | 'down' | 'same';
+}
   
-  export type ChartPeriod = '1D' | '1S' | '1M' | '3M' | '6M' | '1A' | '5A';
-  
-  export interface ChartData {
-    period: ChartPeriod;
-    data: ChartDataPoint[];
-  }
-  
+export interface ChartInfo {
+  name: string;
+  shortName: string;
+  countryName: string;
+  currencyName: string;
+  currencySymbol: string;
+  codeInstrument: string;
+  hourOpen: string;
+  hourClose: string;
+}
+
+export interface ChartHistoryResponse {
+  success: boolean;
+  code: number;
+  data: {
+    info: ChartInfo;
+    chart: ChartDataPoint[];
+  };
+}
+
+export type ChartPeriod = '1D' | '1S' | '1M' | '3M' | '6M' | '1A' | '5A';
+
+export interface ProcessedChartData {
+  period: ChartPeriod;
+  points: ChartDataPoint[];
+  minPrice: number;
+  maxPrice: number;
+  priceChange: number;
+  priceChangePercent: number;
+}

--- a/src/app/core/models/instrument.model.ts
+++ b/src/app/core/models/instrument.model.ts
@@ -1,22 +1,79 @@
-export interface Instrument {
-    symbol: string;
+export interface ConstituentInstrument {
+    codeInstrument: string;
     name: string;
+    shortName: string;
+    pctDay: number;
+    pct30D: number;
+    pctCY: number;
+    pct1Y: number;
     lastPrice: number;
-    change: number;
-    changePercent: number;
-    volume: number;
-    marketCap: number;
-    high: number;
-    low: number;
-    open: number;
-    previousClose: number;
+    datetimeLastPrice: string;
+    volumeMoney: number;
+    accumulatedVolumeMoney: number;
+    tend: 'up' | 'down' | 'same';
+    performanceAbsolute: number;
+    performanceRelative: number;
 }
 
-export interface InstrumentDetail extends Instrument {
-    bid: number;
-    ask: number;
-    dayRange: { min: number; max: number };
-    yearRange: { min: number; max: number };
-    avgVolume: number;
-  }
-  
+export interface ConstituentsResponse {
+    success: boolean;
+    code: number;
+    data: {
+      info: {
+        name: string;
+        shortName: string;
+        countryName: string;
+        codeInstrument: string;
+      };
+      constituents: ConstituentInstrument[];
+    };
+}
+
+export interface InstrumentDetail {
+    info: {
+      name: string;
+      shortName: string;
+      countryName: string;
+      currencyName: string;
+      currencySymbol: string;
+      codeInstrument: string;
+      marketName: string;
+      hourOpen: string;
+      hourClose: string;
+      trading: boolean;
+      exchangeRate: number;
+    };
+    price: {
+      lastPrice: number;
+      datetimeLastPrice: string;
+      openPrice: number;
+      closePrice: number;
+      datetimeClosePrice: string;
+      performanceAbsolute: number;
+      performanceRelative: number;
+      bid: number;
+      bidVolume: number;
+      bidDatetime: string;
+      ask: number;
+      askVolume: number;
+      askDatetime: string;
+      volumeMoney: number;
+      accumulatedVolumeMoney: number;
+      volumeInstrument: number;
+      accumulatedVolumeInstrument: number;
+      tend: 'up' | 'down' | 'same';
+      maxDay: number;
+      minDay: number;
+      min52W: number;
+      max52W: number;
+      pct30D: number;
+      pctRelW52: number;
+      pctRelCY: number;
+    };
+}
+
+export interface InstrumentDetailResponse {
+    success: boolean;
+    code: number;
+    data: InstrumentDetail;
+}


### PR DESCRIPTION
- Update instrument models based on actual JSON responses
- Add ConstituentsResponse and InstrumentDetailResponse types
- Update ChartDataPoint with all fields from history JSON
- Add ChartHistoryResponse type
- Maintain type safety with 'tend' union types
- Add proper timestamp and date handling