### PR TITLE
feat: fully working mock data service with constituents display

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,6 +22,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/assets",
+                "output": "/assets"
               }
             ],
             "styles": [

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MockDataService } from '@core/services/mock-data.service';
-import { ConstituentInstrument, InstrumentDetail, ChartDataPoint } from '@core/models';
+import { MockDataService } from './core/services/mock-data.service';
+import { ConstituentInstrument, InstrumentDetail, ChartDataPoint } from './core/models';
 
 @Component({
   selector: 'app-root',

--- a/src/app/core/services/mock-data.service.ts
+++ b/src/app/core/services/mock-data.service.ts
@@ -5,7 +5,7 @@ import {
   ConstituentsResponse, 
   InstrumentDetailResponse, 
   ChartHistoryResponse 
-} from '@core/models';
+} from '../models';
 
 @Injectable({
   providedIn: 'root'
@@ -17,7 +17,7 @@ export class MockDataService {
 
   getConstituents(): Observable<ConstituentsResponse> {
     return this.http.get<ConstituentsResponse>(
-      `${this.basePath}/constituents/ipsa.json`
+      `${this.basePath}/constituents/constituensList.json`
     );
   }
 
@@ -26,7 +26,7 @@ export class MockDataService {
    */
   getInstrumentHistory(symbol: string): Observable<ChartHistoryResponse> {
     return this.http.get<ChartHistoryResponse>(
-      `${this.basePath}/history/${symbol}.json`
+      `${this.basePath}/history/history-${symbol}.json`
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import { AppComponent } from './app/app.component';
 
-bootstrapApplication(App, appConfig)
+bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
- Update angular.json adding this to assets
```
{
      "glob": "**/*",
      "input": "src/assets",
      "output": "/assets"
}
```
- Fix service path to use 'mock-data' instead of 'assets/mock-data'
- Successfully loading 32 IPSA constituents
- Display working with formatted numbers and percentages
- Color-coded trend indicators (up/down/same)
- Responsive table with hover effects